### PR TITLE
Decorators refactor

### DIFF
--- a/src/transformations/macros/updateComponentConfig.ts
+++ b/src/transformations/macros/updateComponentConfig.ts
@@ -1,0 +1,138 @@
+import ts from "typescript";
+import { TransformState } from "../../classes/transformState";
+import { buildGuardFromType, buildGuardsFromType } from "../../util/functions/buildGuardFromType";
+import { f } from "../../util/factory";
+import { getSuperClasses } from "../../util/functions/getSuperClasses";
+import { NodeMetadata } from "../../classes/nodeMetadata";
+import { withDiagnosticContext } from "../../util/diagnosticsUtils";
+
+function calculateOmittedGuards(
+	state: TransformState,
+	classDeclaration: ts.ClassDeclaration,
+	customAttributes?: ts.ObjectLiteralElementLike,
+) {
+	const omittedNames = new Set<string>();
+	if (f.is.propertyAssignmentDeclaration(customAttributes) && f.is.object(customAttributes.initializer)) {
+		for (const prop of customAttributes.initializer.properties) {
+			if (f.is.string(prop.name) || f.is.identifier(prop.name)) {
+				omittedNames.add(prop.name.text);
+			}
+		}
+	}
+
+	const type = state.typeChecker.getTypeAtLocation(classDeclaration);
+	const property = type.getProperty("attributes");
+	if (!property) return omittedNames;
+
+	const superClass = getSuperClasses(state.typeChecker, classDeclaration)[0];
+	if (!superClass) return omittedNames;
+
+	const superType = state.typeChecker.getTypeAtLocation(superClass);
+	const superProperty = superType.getProperty("attributes");
+	if (!superProperty) return omittedNames;
+
+	const attributes = state.typeChecker.getTypeOfSymbolAtLocation(property, classDeclaration);
+	const superAttributes = state.typeChecker.getTypeOfSymbolAtLocation(superProperty, superClass);
+	for (const { name } of superAttributes.getProperties()) {
+		const prop = state.typeChecker.getTypeOfPropertyOfType(attributes, name);
+		const superProp = state.typeChecker.getTypeOfPropertyOfType(superAttributes, name);
+
+		if (prop && superProp && superProp === prop) {
+			omittedNames.add(name);
+		}
+	}
+
+	return omittedNames;
+}
+
+function updateAttributeGuards(
+	state: TransformState,
+	node: ts.ClassDeclaration,
+	properties: ts.ObjectLiteralElementLike[],
+) {
+	const type = state.typeChecker.getTypeAtLocation(node);
+
+	const property = type.getProperty("attributes");
+	if (!property) return;
+
+	const attributesMeta = NodeMetadata.fromSymbol(state, property);
+	if (!attributesMeta || !attributesMeta.isRequested("intrinsic-component-attributes")) return;
+
+	const attributesType = state.typeChecker.getTypeOfSymbolAtLocation(property, node);
+	if (!attributesType) return;
+
+	const attributes = properties.find((x) => x.name && "text" in x.name && x.name.text === "attributes");
+	const attributeGuards = withDiagnosticContext(
+		node.name ?? node,
+		() => `Failed to generate component attributes: ${state.typeChecker.typeToString(attributesType)}`,
+		() => buildGuardsFromType(state, node.name ?? node, attributesType),
+	);
+
+	const omittedGuards = calculateOmittedGuards(state, node, attributes);
+	const filteredGuards = attributeGuards.filter((x) => !omittedGuards.has((x.name as ts.StringLiteral).text));
+	properties = properties.filter((x) => x !== attributes);
+
+	if (f.is.propertyAssignmentDeclaration(attributes) && f.is.object(attributes.initializer)) {
+		properties.push(
+			f.update.propertyAssignmentDeclaration(
+				attributes,
+				f.update.object(attributes.initializer, [
+					...attributes.initializer.properties.map((v) => state.transformNode(v)),
+					...filteredGuards,
+				]),
+				attributes.name,
+			),
+		);
+	} else {
+		properties.push(f.propertyAssignmentDeclaration("attributes", f.object(filteredGuards)));
+	}
+
+	return properties;
+}
+
+function updateInstanceGuard(
+	state: TransformState,
+	node: ts.ClassDeclaration,
+	properties: ts.ObjectLiteralElementLike[],
+) {
+	const type = state.typeChecker.getTypeAtLocation(node);
+
+	const property = type.getProperty("instance");
+	if (!property) return;
+
+	const attributesMeta = NodeMetadata.fromSymbol(state, property);
+	if (!attributesMeta || !attributesMeta.isRequested("intrinsic-component-instance")) return;
+
+	const superClass = getSuperClasses(state.typeChecker, node)[0];
+	if (!superClass) return;
+
+	const customGuard = properties.find((x) => x.name && "text" in x.name && x.name.text === "instanceGuard");
+	if (customGuard) return;
+
+	const instanceType = state.typeChecker.getTypeOfSymbolAtLocation(property, node);
+	if (!instanceType) return;
+
+	const superType = state.typeChecker.getTypeAtLocation(superClass);
+	const superProperty = superType.getProperty("instance");
+	if (!superProperty) return;
+
+	const superInstanceType = state.typeChecker.getTypeOfSymbolAtLocation(superProperty, superClass);
+	if (!superInstanceType) return;
+
+	if (!type.checker.isTypeAssignableTo(superInstanceType, instanceType)) {
+		const guard = buildGuardFromType(state, node, instanceType);
+		properties.push(f.propertyAssignmentDeclaration("instanceGuard", guard));
+	}
+
+	return properties;
+}
+
+export function updateComponentConfig(
+	state: TransformState,
+	node: ts.ClassDeclaration,
+	properties: ts.ObjectLiteralElementLike[],
+): ts.ObjectLiteralElementLike[] {
+	properties = updateAttributeGuards(state, node, properties) ?? properties;
+	properties = updateInstanceGuard(state, node, properties) ?? properties;
+	return properties;
+}

--- a/src/types/classes.d.ts
+++ b/src/types/classes.d.ts
@@ -6,4 +6,5 @@ export interface ClassInfo {
 	node: ts.Node;
 	name: string;
 	decorators: DecoratorInfo[];
+	containsLegacyDecorator: boolean;
 }

--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -333,6 +333,10 @@ export namespace f {
 		return factory.createComputedPropertyName(expression);
 	}
 
+	export function staticBlockDeclaration(statements: ts.Statement[]) {
+		return factory.createClassStaticBlockDeclaration(block(statements));
+	}
+
 	/// Type Nodes
 
 	export function functionType(


### PR DESCRIPTION
- Fixes a bug where any class with decorators would generate Flamework metadata
- Allows native roblox-ts decorators to generate Flamework metadata, using `@metadata reflect`
  - This means you can now use decorators with custom signatures (e.g generics) and still use them with Flamework
  
Flamework decorators will be deprecated at a later point in time.