### PR TITLE
Fix `Negative numbers should be created in combination with createPrefixUnaryExpression`

### DIFF
--- a/src/util/factory.ts
+++ b/src/util/factory.ts
@@ -56,8 +56,15 @@ export namespace f {
 		return factory.createArrayLiteralExpression(values, multiLine);
 	}
 
-	export function number(value: number | string, flags?: ts.TokenFlags) {
-		return factory.createNumericLiteral(value, flags);
+	export function number(value: number, flags?: ts.TokenFlags) {
+		if (value < 0) {
+			return factory.createPrefixUnaryExpression(
+				ts.SyntaxKind.MinusToken,
+				factory.createNumericLiteral(Math.abs(value), flags),
+			);
+		} else {
+			return factory.createNumericLiteral(value, flags);
+		}
 	}
 
 	export function identifier(name: string, unique = false) {


### PR DESCRIPTION
```
Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression
    at Object.createNumericLiteral (c:\Roblox\Project\node_modules\typescript\lib\typescript.js:21074:13)
    at Object.number (c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\util\factory.js:75:24)
    at buildUserMacro (c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:204:31)
    at c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:175:106
    at Array.map (<anonymous>)
    at buildUserMacro (c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:175:72)
    at c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:175:106
    at Array.map (<anonymous>)
    at buildUserMacro (c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:175:72)
    at transformUserMacro (c:\Roblox\Project\node_modules\rbxts-transformer-flamework\out\transformations\transformUserMacro.js:80:23)
````
It seems to occur in TypeScript 5.4 and later versions. ([typescript PR](https://github.com/microsoft/TypeScript/pull/56570))