### PR TITLE
Fix comment directives bug

### DIFF
--- a/src/transformations/transformFile.ts
+++ b/src/transformations/transformFile.ts
@@ -11,6 +11,8 @@ export function transformFile(state: TransformState, file: ts.SourceFile): ts.So
 
 	const imports = state.fileImports.get(file.fileName);
 	if (imports) {
+		const firstStatement = statements[0];
+
 		statements.unshift(
 			...imports.map((info) =>
 				f.importDeclaration(
@@ -19,6 +21,12 @@ export function transformFile(state: TransformState, file: ts.SourceFile): ts.So
 				),
 			),
 		);
+
+		// steal comments from original first statement so that comment directives work properly
+		if (firstStatement && statements[0]) {
+			ts.copyComments(firstStatement, statements[0]);
+			ts.removeAllComments(firstStatement);
+		}
 	}
 
 	for (const diag of Diagnostics.flush()) {


### PR DESCRIPTION
Comment directives like `//!native` are usually bubbled up to the top by roblox-ts. Flamework currently breaks this when inserting import statements.

This PR fixes it by stealing the comments from the first statement and applying it to the first generated import.

### Input
```ts
//!native
//!test
// foo
import { Service } from "@flamework/core"; // bar
```

### Before

**`.transformed.ts`**
```ts
import { Reflect as Reflect } from "@flamework/core";
//!native
//!test
// foo
import { Service } from "@flamework/core"; // bar
```

**`.lua`**
```lua
-- Compiled with roblox-ts v2.3.0-dev-3a89c93
local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("include"):WaitForChild("RuntimeLib"))
local Reflect = TS.import(script, game:GetService("ReplicatedStorage"), "include", "node_modules", "@flamework", "core", "out").Reflect
--!native
--!test
-- foo
local Service = TS.import(script, game:GetService("ReplicatedStorage"), "include", "node_modules", "@flamework", "core", "out").Service
```

### After

**`.transformed.ts`**
```ts
//!native
//!test
// foo
import { Reflect as Reflect } from "@flamework/core"; // bar
import { Service } from "@flamework/core";
```

**`.lua`**
```lua
--!native
--!test
-- Compiled with roblox-ts v2.3.0-dev-3a89c93
local TS = require(game:GetService("ReplicatedStorage"):WaitForChild("include"):WaitForChild("RuntimeLib"))
-- foo
local Reflect = TS.import(script, game:GetService("ReplicatedStorage"), "include", "node_modules", "@flamework", "core", "out").Reflect
local Service = TS.import(script, game:GetService("ReplicatedStorage"), "include", "node_modules", "@flamework", "core", "out").Service
```